### PR TITLE
Updated gitignore with the smashbox configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.py[cod]
+etc/smashbox.conf
 
 # C extensions
 *.so


### PR DESCRIPTION
configuration of smashbox shouldn't be tracked by git
