### PR TITLE
src folder should be ignored too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.py[cod]
 etc/smashbox.conf
+src/
 
 # C extensions
 *.so


### PR DESCRIPTION
That src folder contains the results of the pip installation
