### PR TITLE
add support for the loop argument to loop over a test run

### DIFF
--- a/bin/smash
+++ b/bin/smash
@@ -206,6 +206,7 @@ def main():
             run_multiprocessing_engine(config,os.path.abspath(t))
 
       for j in range(1,args.loop+1):
+         log_quiet ("Running iteration %d" % j)
          if args.all_testsets or args.testset is not None:
             smashbox.no_engine.testsets=[None]
             execfile(os.path.abspath(t),smashbox.no_engine.__dict__)

--- a/bin/smash
+++ b/bin/smash
@@ -42,6 +42,7 @@ def main():
    parser.add_argument('--keep-going',dest="keep_going",action="store_true",default=False,help='do not abort the execution on the first failed testcase')
    parser.add_argument('--all-testsets', '-a', dest="all_testsets", action="store_true", help='run all testsets defined within each test script file')
    parser.add_argument('--testset', '-t', dest="testset", action="store", default=None, type=int, help='run just one testset specified by index, starting from 0')
+   parser.add_argument('--loop', '-l', dest="loop", action="store", default=1, type=int, help='number of times a test command should be executed')
 
    args = parser.parse_args()
 
@@ -204,17 +205,18 @@ def main():
          if not args.dry_run:
             run_multiprocessing_engine(config,os.path.abspath(t))
 
-      if args.all_testsets or args.testset is not None:
-         smashbox.no_engine.testsets=[None]
-         execfile(os.path.abspath(t),smashbox.no_engine.__dict__)
+      for j in range(1,args.loop+1):
+         if args.all_testsets or args.testset is not None:
+            smashbox.no_engine.testsets=[None]
+            execfile(os.path.abspath(t),smashbox.no_engine.__dict__)
 
-         if args.all_testsets:
-            for i,ts in enumerate(smashbox.no_engine.testsets):
-               run_test(ts,i)
+            if args.all_testsets:
+               for i,ts in enumerate(smashbox.no_engine.testsets):
+                  run_test(ts,i)
+            else:
+               run_test(smashbox.no_engine.testsets[args.testset],args.testset)
          else:
-            run_test(smashbox.no_engine.testsets[args.testset],args.testset)
-      else:
-         run_test(None)
+            run_test(None)
 
             
 


### PR DESCRIPTION
`bin/smash --loop <int>`

Fixes #51 

Loops int times over the test command, including test sets.  Default is 1.

@nickvergessen @jvillafanez @SergioBertolinSG  for review
