### PR TITLE
added scp_port to template for scp commands

### DIFF
--- a/etc/smashbox.conf.template
+++ b/etc/smashbox.conf.template
@@ -132,3 +132,7 @@ reset_server_log = False
 # used in a test run to allow for more users sharing at time
 #
 share_sets = 1
+
+#
+# scp port to be used in scp commands, used primarily when copying over the server log file
+scp_port=22

--- a/python/smashbox/utilities/__init__.py
+++ b/python/smashbox/utilities/__init__.py
@@ -496,7 +496,7 @@ def scrape_log_file(d):
         return
 
     d = make_workdir()
-    cmd = 'scp root@%s:%s/owncloud.log %s/.' % (config.oc_server, config.oc_server_datadirectory, d)
+    cmd = 'scp -P %d root@%s:%s/owncloud.log %s/.' % (config.scp_port, config.oc_server, config.oc_server_datadirectory, d)
     rtn_code = runcmd(cmd)
 
     logger.info('copy command returned %s', rtn_code)


### PR DESCRIPTION
Users can now specify which port to use for scp commands.  The default is port 22.

Fix #46 

@jvillafanez @SergioBertolinSG 
