### PR TITLE
Fix failing shareDir test that assumed the dir would not exist

### DIFF
--- a/lib/oc-tests/test_shareDir.py
+++ b/lib/oc-tests/test_shareDir.py
@@ -216,9 +216,14 @@ def shareeTwo(step):
     step (2, 'Sharee Two creates workdir')
     d = make_workdir()
 
-    procName = reflection.getProcessName()
-    dirName = "%s/%s"%(procName, 'localShareDir')
-    localDir = make_workdir(dirName)
+    # create a folder so we get a naming conflict later when the folder is shared
+    dirName = os.path.join(d,'localShareDir')
+    make_workdir(dirName)
+
+    # Do we want to test the client's conflict resolution or the server's?
+    # Currently we test the server, to test the client comment out the sync below
+    run_ocsync(d,user_num=3)
+    list_files(d)
 
     step (13, 'Sharee two validates share file')
 
@@ -227,25 +232,40 @@ def shareeTwo(step):
 
     sharedFile = os.path.join(d,'TEST_FILE_USER_RESHARE.dat')
     logger.info ('Checking that %s is present in local directory for Sharee Two', sharedFile)
-    error_check(os.path.exists(sharedFile), "File %s should exist" %sharedFile)
+    expect_exists(sharedFile)
 
     step (15, 'Sharee two validates directory re-share')
 
     run_ocsync(d,user_num=3)
     list_files(d)
 
-    sharedFile = os.path.join(d,'localShareDir')
-    logger.info ('Checking that %s is present in local directory for Sharee Two', sharedFile)
-    error_check(os.path.exists(sharedFile), "File %s should exist" %sharedFile)
+    localDir = os.path.join(d,'localShareDir')
+    logger.info ('Checking that local dir %s is still present in local directory for Sharee Two', localDir)
+    expect_exists(localDir)
+
+    localDirFile = os.path.join(d,'localShareDir/TEST_FILE_USER_SHARE.dat')
+    logger.info ('Checking that local dir does not contain the shared file %s for Sharee Two', localDirFile)
+    expect_does_not_exist(localDirFile)
+
+    sharedDir = os.path.join(d, 'localShareDir (2)')
+    logger.info ('Checking that shared dir %s is present in local directory for Sharee Two', sharedDir)
+    expect_exists(sharedDir)
+
+    sharedDirFile = os.path.join(d, 'localShareDir (2)/TEST_FILE_USER_SHARE.dat')
+    logger.info ('Checking that shared dir does contain the shared file %s for Sharee Two', sharedDirFile)
+    expect_exists(sharedDirFile)
 
     step (18, 'Sharee two syncs and validates directory does not exist')
 
     run_ocsync(d,user_num=3)
     list_files(d)
 
-    sharedFile = os.path.join(d,'localShareDir')
-    logger.info ('Checking that %s is not present in sharee local directory', sharedFile)
-    expect_does_not_exist(sharedFile)
+    localDir = os.path.join(d, 'localShareDir')
+    logger.info ('Checking that local directory %s is still present in sharee local directory', localDir)
+    expect_exists(localDir)
+
+    sharedDir = os.path.join(d, 'localShareDir (2)')
+    logger.info ('Checking that %s is not present in sharee local directory', sharedDir)
+    expect_does_not_exist(sharedDir)
 
     step (19, 'Sharee Two final step')
-


### PR DESCRIPTION
### Reasons why the test was incorrect:
1. ShareeTwo creates a folder `localShareDir` in step 2
2. The folder gets shared with the user as `localShareDir`
3. The shared folder `localShareDir` gets synced as `localShareDir (2)` (conflict rule of the client/server)
4. The share is revoked
5. The test expects the folder `localShareDir` being deleted, although `localShareDir (2)` was the shared file.
### Solution

I fixed the test, so it correctly checks that the folder share is in `localShareDir (2)` instead of `localShareDir`

I also changed the error_checks to use the `expect_exists` and `expect_does_not_exist` methods instead of duplicating them

@jnfrmarks 
