### PR TITLE
Fix the user and group names in shareGroup.py

### DIFF
--- a/lib/oc-tests/test_shareGroup.py
+++ b/lib/oc-tests/test_shareGroup.py
@@ -270,7 +270,7 @@ def admin(step):
 
     user3 = "%s%i"%(config.oc_account_name, 3)
     group1 = "%s%i"%(config.oc_group_name, 1)
-    add_user_to_group(user3, group1)
+    remove_user_from_group(user3, group1)
 
     step (16, 'Admin final step')
 

--- a/lib/oc-tests/test_shareGroup.py
+++ b/lib/oc-tests/test_shareGroup.py
@@ -88,7 +88,9 @@ def setup(step):
     reset_owncloud_group(num_groups=config.oc_number_test_groups)
     check_groups(config.oc_number_test_groups)
 
-    add_user_to_group('user3', 'testgroup1')
+    user3 = "%s%i"%(config.oc_account_name, 3)
+    group1 = "%s%i"%(config.oc_group_name, 1)
+    add_user_to_group(user3, group1)
 
     reset_rundir()
     reset_server_log_file()
@@ -265,7 +267,10 @@ def admin(step):
 
 
     step (14, 'Admin user removes user from group')
-    remove_user_from_group('user3', 'testgroup1')
+
+    user3 = "%s%i"%(config.oc_account_name, 3)
+    group1 = "%s%i"%(config.oc_group_name, 1)
+    add_user_to_group(user3, group1)
 
     step (16, 'Admin final step')
 


### PR DESCRIPTION
The hardcoded names made it fail for me way earlier then for you

@jnfrmarks 
