### PR TITLE
Revert "search for go away message in server log file"

### DIFF
--- a/python/smashbox/utilities/__init__.py
+++ b/python/smashbox/utilities/__init__.py
@@ -523,10 +523,6 @@ def scrape_log_file(d):
     rtn_code = runcmd(cmd, ignore_exitcode=True, log_warning=False)
     error_check(rtn_code > 0, "\"Stat Failed\" message found in server log file")
 
-    cmd = "grep -i \"go away\" %s/owncloud.log" % d
-    rtn_code = runcmd(cmd, ignore_exitcode=True, log_warning=False)
-    error_check(rtn_code > 0, "\"go away\" message found in server log file")
-
 
 # ###### API Calls ############
 


### PR DESCRIPTION
This reverts commit 5b908d8b37b590672329913b751bb27dee6ca6a9.

The logs are not created any more with this message, so the check can go, to reduce the difference to cernbox
