### PR TITLE
Fix failing test filenames.py

### DIFF
--- a/lib/test_filenames.py
+++ b/lib/test_filenames.py
@@ -62,6 +62,7 @@ def creator(step):
     step(1,'create initial content and sync')
 
     d = make_workdir()
+    run_ocsync(d)
 
     namepatterns = [
         "space1 testfile.dat",

--- a/lib/test_filenames.py
+++ b/lib/test_filenames.py
@@ -1,4 +1,5 @@
-from smashbox.utilities import * 
+from smashbox.utilities import *
+from smashbox.utilities.hash_files import get_files
 from smashbox.utilities.hash_files import count_files
 
 import os
@@ -106,7 +107,7 @@ def creator(step):
             filenames.append(nn)
             createfile(os.path.join(d,nn),'1',count=filesizeKB,bs=1000)
 
-    files_1 = os.listdir(d)
+    files_1 = get_files(d)
     N = count_files(d)
 
     shared = reflection.getSharedObject()
@@ -119,10 +120,13 @@ def creator(step):
         run_ocsync(d)
         error_check(count_files(d) == N, "some files lost!")
 
-    files_2 = os.listdir(d)
+    files_2 = get_files(d)
 
     for fn in set(files_1)-set(files_2):
         error_check(False, "the file has disappeared: %s"%repr(fn))
+
+    for fn in set(files_2)-set(files_1):
+        error_check(False, "the file has appeared: %s" % repr(fn))
 
 
 

--- a/python/smashbox/utilities/hash_files.py
+++ b/python/smashbox/utilities/hash_files.py
@@ -27,14 +27,22 @@ BLOCK_SIZE = 1024*1024
 import os
 import fnmatch
 
-def count_files(wdir,filemask=None):
+
+def get_files(wdir, filemask=None):
     fl = os.listdir(wdir)
     # if filemask defined then filter names out accordingly
     if filemask:
-        fl = fnmatch.filter(fl,filemask.replace('{md5}','*'))
-    nf = len(set(fl) - set(config.ignored_files))
-    logger.info('%s: %d files found',wdir,nf)
+        fl = fnmatch.filter(fl, filemask.replace('{md5}', '*'))
+    fl = set(fl) - set(config.ignored_files)
+    return fl
+
+
+def count_files(wdir, filemask=None):
+    fl = get_files(wdir, filemask)
+    nf = len(fl)
+    logger.info('%s: %d files found', wdir, nf)
     return nf
+
 
 def size2nbytes(size):
     """ Return the number of bytes from the size specification (size may be a distribution or nbytes directly).


### PR DESCRIPTION
Test fails better now:

```
ERROR - propagator - the file has not been propagated: ' '
    error_check(False, "the file has not been propagated: %s"%repr(fn))
    failed in propagator()
    ["/home/nickv/ownCloud/Smashbox/smashbox/lib/test_filenames.py" at line 157]
ERROR - propagator - 1 error(s) reported
```

So we fail to sync a file that only has a single space as a name. Not sure if that is desired or not.
