### PR TITLE
Worker must return error code when errors detected

### DIFF
--- a/python/smashbox/multiprocessing_engine.py
+++ b/python/smashbox/multiprocessing_engine.py
@@ -171,6 +171,8 @@ class _smash_:
             import smashbox.utilities
             if smashbox.utilities.reported_errors:
                logger.error('%s error(s) reported',len(smashbox.utilities.reported_errors))
+               import sys
+               sys.exit(2)
                   
 
     @staticmethod


### PR DESCRIPTION
The worker did not return errors when logging "ERROR" statements.
Now it does.

This will then propagate to the supervisor which will return it to "bin/smash" that will then return a non-zero status code too.

Fix #95, #63

Please review @nickvergessen @DeepDiver1975 @jnfrmarks @jvillafanez 
