### PR TITLE
Always reset "test" and correctly specify the numbers of users in shareGroup

### DIFF
--- a/lib/oc-tests/test_shareGroup.py
+++ b/lib/oc-tests/test_shareGroup.py
@@ -82,7 +82,7 @@ OCS_PERMISSION_ALL = 31
 def setup(step):
 
     step (1, 'create test users')
-    reset_owncloud_account(config.oc_number_test_users)
+    reset_owncloud_account(num_test_users=config.oc_number_test_users)
     check_users(num_test_users=config.oc_number_test_users)
 
     reset_owncloud_group(num_groups=config.oc_number_test_groups)

--- a/python/smashbox/utilities/__init__.py
+++ b/python/smashbox/utilities/__init__.py
@@ -37,11 +37,11 @@ def reset_owncloud_account(reset_procedure=None, num_test_users=None):
         logger.info('reset_owncloud_account (%s) for %d users', reset_procedure, num_test_users)
 
     if reset_procedure == 'delete':
-        if num_test_users is None:
-            delete_owncloud_account(config.oc_account_name)
-            create_owncloud_account(config.oc_account_name, config.oc_account_password)
-            login_owncloud_account(config.oc_account_name, config.oc_account_password)
-        else:
+        delete_owncloud_account(config.oc_account_name)
+        create_owncloud_account(config.oc_account_name, config.oc_account_password)
+        login_owncloud_account(config.oc_account_name, config.oc_account_password)
+
+        if num_test_users is not None:
             for i in range(1, num_test_users + 1):
                 username = "%s%i" % (config.oc_account_name, i)
                 delete_owncloud_account(username)


### PR DESCRIPTION
1. Always reset "test" because it is used by the reset method
2. Correctly specify the number of users to reset in shareGroup

Fix #105 

Fixes the last failing test on jenkins

@PVince81 
