### PR TITLE
Make sure that moving a non-existing file returns a 404

### DIFF
--- a/lib/owncloud/test_moveFileStatusCode.py
+++ b/lib/owncloud/test_moveFileStatusCode.py
@@ -1,0 +1,47 @@
+from owncloud import HTTPResponseError
+
+__doc__ = """
+
+Test moving a file via webdav
+
+"""
+
+from smashbox.utilities import *
+
+@add_worker
+def move_non_existing_file(step):
+
+    step(1, 'Create a folder and a file')
+    d = make_workdir()
+    dir_name = os.path.join(d, 'folder')
+    local_dir = make_workdir(dir_name)
+
+    createfile(os.path.join(d, 'file1.txt'), '0', count=1000, bs=50)
+    createfile(os.path.join(local_dir, 'file2.txt'), '1', count=1000, bs=50)
+    run_ocsync(d, user_num=1)
+
+    expect_webdav_exist('file1.txt', user_num=1)
+    expect_webdav_exist(os.path.join('folder', 'file2.txt'), user_num=1)
+
+    step(2, 'Move the file into the folder')
+
+    api = get_oc_api()
+    api.login("%s%i" % (config.oc_account_name, 1), config.oc_account_password)
+
+    try:
+        api.move('file1.txt', os.path.join('folder', 'file2.txt'))
+    except HTTPResponseError as err:
+        error_check(
+            False,
+            'Server replied with status code: %i' % err.status_code
+        )
+
+    step(3, 'Move non existing file into the folder')
+
+    try:
+        api.move('file1.txt', os.path.join('folder', 'file2.txt'))
+    except HTTPResponseError as err:
+        error_check(
+            err.status_code == 404,
+            'Server replied with status code: %i' % err.status_code
+        )


### PR DESCRIPTION
Coverage for https://github.com/owncloud/core/pull/20076

@PVince81 @rullzer @DeepDiver1975 

Without the fix:

```
2015-10-27 10:18:25,852 - ERROR - move_non_existing_file - No Server Error should be triggered when moving a file 'No Server Error should be triggered when moving a file' failed in move_non_existing_file() ["/home/nickv/ownCloud/Smashbox/smashbox/lib/owncloud/test_moveNonExistingFile.py" at line 54]
2015-10-27 10:18:26,866 - ERROR - move_non_existing_file - 1 error(s) reported
SUMMARY:smash.:Elapsed time: 7s (0:00:07.782916)
CRITICAL:smash.:Aborting run -- non-zero exit code (2)
```

With the fix:

```
SUMMARY:smash.:Elapsed time: 7s (0:00:07.960833)
```
