### PR TITLE
Fix default template file for configuration

### DIFF
--- a/bin/config_gen
+++ b/bin/config_gen
@@ -6,7 +6,7 @@ exeDir = os.path.abspath(os.path.normpath(os.path.dirname(sys.argv[0])))
 pythonDir = os.path.join(os.path.dirname(exeDir), 'python' )
 sys.path.insert(0, pythonDir)
 etcDir = os.path.join(os.path.dirname(exeDir), 'etc')
-defaultTemplateFile = os.path.join(etcDir, 'smashbox.conf.template')
+defaultTemplateFile = os.path.join(etcDir, 'smashbox.conf.template-owncloud')
 defaultOutputFile = os.path.join(etcDir, 'smashbox.conf')
 
 import smashbox.configgen.generator as generator


### PR DESCRIPTION
Default template file for the config generator (etc/smashbox.conf.template) isn't usable in master branch for generation purposes. The new one (etc/smashbox.conf.template-owncloud) can be used instead.

@nickvergessen 
