### PR TITLE
Add support for monitoring and jenkins monitoring endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,53 @@ Examples:
 
 You will find main log files in ~/smashdir/log* and all temporary files and detailed logs for each test-case in ~/smashdir/<test-case>
 
+Monitoring integration
+=======================
+
+Currently, monitoring module is supporting `local` and `prometheus` endpoints. Prometheus endpoint can be used in integration with Jenkins.
+
+By default, two values are prepared for export, 'total_duration' and 'number_of_queries', however one can embed inside the test their custom variables using e.g. `commit_to_monitoring("download_duration",time1-time0)` inside `lib/test_nplusone.py` test.
+
+**Export to local monitor example:**
+
+Executing
+
+```
+bin/smash -t 1 -o monitoring_type=local lib/test_nplusone.py
+```
+
+will execute index `1` of `test_nplusone` test and adding option flag `-o monitoring_type=local` will result in the below output if test has been completed successfully
+
+```
+download_duration 0.750847816467
+upload_duration 1.4001121521
+returncode 0
+elapsed 6.87230300903
+```
+
+or below in case of failure
+
+```
+returncode 2
+elapsed 7.0446870327
+```
+
+**Export to prometheus with jenkins example:**
+
+Executing
+
+```
+bin/smash -t 1 -o monitoring_type=prometheus -o endpoint=http://localhost:9091/metrics/job/jenkins/instance/smashbox -o duration_label=jenkins_smashbox_test_duration -o queries_label=jenkins_smashbox_db_queries -o owncloud=daily-master -o client=2.3.1 -o suite=nplusonet1 -o build=test_build1 lib/test_nplusone.py
+```
+
+will result in:
+ * pushing the monitoring points to the Prometheus endpoint `http://localhost:9091/metrics/job/jenkins/instance/smashbox`
+ * Adding flags `-o duration_label=jenkins_smashbox_test_duration` and `-o queries_label=jenkins_smashbox_db_queries` will cause default results 'total_duration' and 'number_of_queries' to be exported to Prometheus.
+ * Additional flags `-o queries_label=jenkins_smashbox_db_queries`, `-o owncloud=daily-master`, `-o client=2.3.1`, `-o suite=nplusonet1`, `-o build=test_build1` can be used in order to distinguish smashbox runs
+
+or below in case of failure to push to monitoring
+
+`curl: (7) Failed to connect to localhost port 9091: Connection refused`
 
 Different client/server
 =======================

--- a/bin/smash
+++ b/bin/smash
@@ -242,7 +242,8 @@ def main():
          logger.critical("Wrong testset specification: %d index out of range for %s",args.testset,barename(t))
          sys.exit(1)
 
-      for j in range(1,args.loop+1):
+      j = 1
+      while j <= args.loop or args.loop == 0:
          log_quiet ("Running iteration %d" % j)
 
          if not smashbox.no_engine.testsets:
@@ -254,6 +255,7 @@ def main():
             else:
                i = args.testset # this may be None if no testset indicated
                run_test(t,j,i)
+         j=j+1
 
    if args.dry_run:
       log_quiet('*** DRY RUN ***')

--- a/corruption_test/run_nplusone_loop
+++ b/corruption_test/run_nplusone_loop
@@ -10,9 +10,10 @@ conf_file = os.environ.get('SMASHBOX_CONF',os.path.join(thisdir,"smashbox.conf")
 
 dirs = {'thisdir':thisdir,'smashdir':smashdir, 'conf_file':conf_file}
 
-os.environ['OWNCLOUD_MAX_PARALLEL'] = '10'
+os.environ['OWNCLOUD_MAX_PARALLEL'] = '3'
 
-os.environ['OWNCLOUD_USE_LEGACY_JOBS'] = '1'
+# this disables the checksumming!
+#os.environ['OWNCLOUD_USE_LEGACY_JOBS'] = '1'
 
 import datetime
 now = datetime.datetime.now().strftime('%Y-%m-%d-%H%M%S')
@@ -35,6 +36,9 @@ i = 1
 
 dirs['options']="-o nplusone_nfiles=20 -o nplusone_filesize='(5.0,1.37)'" # --keep-state"
 #dirs['options']="-o nplusone_nfiles=20 -o nplusone_filesize=30000000"
+
+# infinite loop and ignore any casual errors (stop on fatal errors only)
+dirs['options'] += " --loop=0 --keep-going "
 
 cmd = '%(smashdir)s/bin/smash -c %(conf_file)s %(options)s %(smashdir)s/lib/test_nplusone.py' % dirs
 

--- a/lib/test_nplusone.py
+++ b/lib/test_nplusone.py
@@ -8,9 +8,13 @@ __doc__ = """ Add nfiles to a directory and check consistency.
 
 from smashbox.utilities import *
 from smashbox.utilities.hash_files import *
+from smashbox.utilities.monitoring import push_to_monitoring
 
 nfiles = int(config.get('nplusone_nfiles',10))
 filesize = config.get('nplusone_filesize',1000)
+
+# optional fs check before files are uploaded by worker0
+fscheck = config.get('nplusone_fscheck',False)
 
 if type(filesize) is type(''):
     filesize = eval(filesize)
@@ -54,8 +58,29 @@ def worker0(step):
 
     step(2,'Add %s files and check if we still have k1+nfiles after resync'%nfiles)
 
+    total_size=0
+    sizes=[]
+
+    # compute the file sizes in the set
     for i in range(nfiles):
-        create_hashfile(d,size=filesize)
+        size=size2nbytes(filesize)
+        sizes.append(size)
+        total_size+=size
+
+    time0=time.time()
+
+    logger.log(35,"Timestamp %f Files %d TotalSize %d",time.time(),nfiles,total_size)
+
+    # create the test files
+    for size in sizes:
+        create_hashfile(d,size=size)
+
+    if fscheck:
+        # drop the caches (must be running as root on Linux)
+        runcmd('echo 3 > /proc/sys/vm/drop_caches')
+        
+        ncorrupt = analyse_hashfiles(d)[2]
+        fatal_check(ncorrupt==0, 'Corrupted files ON THE FILESYSTEM (%s) found'%ncorrupt)
 
     run_ocsync(d)
 
@@ -68,6 +93,17 @@ def worker0(step):
     fatal_check(ncorrupt==0, 'Corrupted files (%s) found'%ncorrupt)
 
     logger.info('SUCCESS: %d files found',k1)
+
+    step(4,"Final report")
+
+    time1 = time.time()
+    push_to_monitoring("cernbox.cboxsls.nplusone.nfiles",nfiles)
+    push_to_monitoring("cernbox.cboxsls.nplusone.total_size",total_size)
+    push_to_monitoring("cernbox.cboxsls.nplusone.elapsed",time1-time0)
+    push_to_monitoring("cernbox.cboxsls.nplusone.total_size",total_size)
+    push_to_monitoring("cernbox.cboxsls.nplusone.transfer_rate",total_size/(time1-time0))
+    push_to_monitoring("cernbox.cboxsls.nplusone.worker0.synced_files",k1-k0)
+
         
 @add_worker
 def worker1(step):
@@ -83,9 +119,13 @@ def worker1(step):
     ncorrupt = analyse_hashfiles(d)[2]
     k1 = count_files(d)
 
+    push_to_monitoring("cernbox.cboxsls.nplusone.worker1.synced_files",k1-k0)
+    push_to_monitoring("cernbox.cboxsls.nplusone.worker1.cor",ncorrupt)
+                       
     error_check(k1-k0==nfiles,'Expecting to have %d files more: see k1=%d k0=%d'%(nfiles,k1,k0))
 
-    fatal_check(ncorrupt==0, 'Corrupted files (%s) found'%ncorrupt)
+    fatal_check(ncorrupt==0, 'Corrupted files (%d) found'%ncorrupt) #Massimo 12-APR
+
 
 
 

--- a/lib/test_nplusone.py
+++ b/lib/test_nplusone.py
@@ -8,7 +8,7 @@ __doc__ = """ Add nfiles to a directory and check consistency.
 
 from smashbox.utilities import *
 from smashbox.utilities.hash_files import *
-from smashbox.utilities.monitoring import push_to_monitoring
+from smashbox.utilities.monitoring import commit_to_monitoring
 
 nfiles = int(config.get('nplusone_nfiles',10))
 filesize = config.get('nplusone_filesize',1000)
@@ -78,7 +78,7 @@ def worker0(step):
     if fscheck:
         # drop the caches (must be running as root on Linux)
         runcmd('echo 3 > /proc/sys/vm/drop_caches')
-        
+
         ncorrupt = analyse_hashfiles(d)[2]
         fatal_check(ncorrupt==0, 'Corrupted files ON THE FILESYSTEM (%s) found'%ncorrupt)
 
@@ -97,12 +97,12 @@ def worker0(step):
     step(4,"Final report")
 
     time1 = time.time()
-    push_to_monitoring("cernbox.cboxsls.nplusone.nfiles",nfiles)
-    push_to_monitoring("cernbox.cboxsls.nplusone.total_size",total_size)
-    push_to_monitoring("cernbox.cboxsls.nplusone.elapsed",time1-time0)
-    push_to_monitoring("cernbox.cboxsls.nplusone.total_size",total_size)
-    push_to_monitoring("cernbox.cboxsls.nplusone.transfer_rate",total_size/(time1-time0))
-    push_to_monitoring("cernbox.cboxsls.nplusone.worker0.synced_files",k1-k0)
+    commit_to_monitoring("cernbox.cboxsls.nplusone.nfiles",nfiles)
+    commit_to_monitoring("cernbox.cboxsls.nplusone.total_size",total_size)
+    commit_to_monitoring("cernbox.cboxsls.nplusone.elapsed",time1-time0)
+    commit_to_monitoring("cernbox.cboxsls.nplusone.total_size",total_size)
+    commit_to_monitoring("cernbox.cboxsls.nplusone.transfer_rate",total_size/(time1-time0))
+    commit_to_monitoring("cernbox.cboxsls.nplusone.worker0.synced_files",k1-k0)
 
         
 @add_worker
@@ -119,9 +119,9 @@ def worker1(step):
     ncorrupt = analyse_hashfiles(d)[2]
     k1 = count_files(d)
 
-    push_to_monitoring("cernbox.cboxsls.nplusone.worker1.synced_files",k1-k0)
-    push_to_monitoring("cernbox.cboxsls.nplusone.worker1.cor",ncorrupt)
-                       
+    commit_to_monitoring("cernbox.cboxsls.nplusone.worker1.synced_files",k1-k0)
+    commit_to_monitoring("cernbox.cboxsls.nplusone.worker1.cor",ncorrupt)
+
     error_check(k1-k0==nfiles,'Expecting to have %d files more: see k1=%d k0=%d'%(nfiles,k1,k0))
 
     fatal_check(ncorrupt==0, 'Corrupted files (%d) found'%ncorrupt) #Massimo 12-APR

--- a/python/smashbox/multiprocessing_engine.py
+++ b/python/smashbox/multiprocessing_engine.py
@@ -185,7 +185,7 @@ class _smash_:
         from multiprocessing import Process, Manager
 
         import smashbox.utilities
-        smashbox.utilities.setup_test()        
+        smashbox.utilities.setup_test()
 
         manager = Manager()
 
@@ -214,12 +214,17 @@ class _smash_:
         for p in _smash_.all_procs:
             p.join()
 
-        smashbox.utilities.finalize_test()
-
+        returncode = 0
         for p in _smash_.all_procs:
            if p.exitcode != 0:
-              import sys
-              sys.exit(p.exitcode)
+              returncode = p.exitcode
+              break
+
+        smashbox.utilities.finalize_test(returncode)
+
+        if returncode != 0:
+            import sys
+            sys.exit(returncode)
 
 def add_worker(f,name=None):
     """ Decorator for worker functions in the user-defined test

--- a/python/smashbox/multiprocessing_engine.py
+++ b/python/smashbox/multiprocessing_engine.py
@@ -201,6 +201,8 @@ class _smash_:
 
         _smash_.steps = manager.list([0 for x in range(len(_smash_.workers))])
 
+        import time
+        t1 = time.time()
         # first worker => process number == 0
         for i,f_n in enumerate(_smash_.workers):
             f = f_n[0]
@@ -214,13 +216,14 @@ class _smash_:
         for p in _smash_.all_procs:
             p.join()
 
+        total_duration = time.time() - t1
         returncode = 0
         for p in _smash_.all_procs:
            if p.exitcode != 0:
               returncode = p.exitcode
               break
 
-        smashbox.utilities.finalize_test(returncode)
+        smashbox.utilities.finalize_test(returncode, total_duration)
 
         if returncode != 0:
             import sys

--- a/python/smashbox/utilities/__init__.py
+++ b/python/smashbox/utilities/__init__.py
@@ -71,7 +71,7 @@ def setup_test():
     reset_rundir()
     reset_server_log_file()
 
-def finalize_test(returncode):
+def finalize_test(returncode, total_duration):
     """ Finalize hooks run after last worker terminated.
     This is run under the name of the "supervisor" worker.
 
@@ -83,9 +83,12 @@ def finalize_test(returncode):
     """
     d = make_workdir()
     scrape_log_file(d)
-    push_to_monitoring(returncode)
+    push_to_monitoring(returncode, total_duration)
 
 ######### HELPERS
+
+def log_info(message):
+    logger.info(message)
 
 def reset_owncloud_account(reset_procedure=None, num_test_users=None):
     """ 

--- a/python/smashbox/utilities/__init__.py
+++ b/python/smashbox/utilities/__init__.py
@@ -8,6 +8,7 @@ import requests
 
 # Utilities to be used in the test-cases.
 from smashbox.utilities.version import version_compare
+from smashbox.utilities.monitoring import push_to_monitoring
 
 
 def compare_oc_version(compare_to, operator):
@@ -50,7 +51,7 @@ def compare_client_version(compare_to, operator):
 def OWNCLOUD_CHUNK_SIZE(factor=1):
     """Calculate file size as a fraction of owncloud client's default chunk size.
     """
-    return int(20*1024*1024*factor) # 20MB as of client 1.7 
+    return int(10*1024*1024*factor) # 10MB as of client 2.3
 
 
 ######## TEST SETUP AND PREPARATION
@@ -69,9 +70,8 @@ def setup_test():
     reset_owncloud_account(num_test_users=config.oc_number_test_users)
     reset_rundir()
     reset_server_log_file()
-    
 
-def finalize_test():
+def finalize_test(returncode):
     """ Finalize hooks run after last worker terminated.
     This is run under the name of the "supervisor" worker.
 
@@ -83,6 +83,7 @@ def finalize_test():
     """
     d = make_workdir()
     scrape_log_file(d)
+    push_to_monitoring(returncode)
 
 ######### HELPERS
 

--- a/python/smashbox/utilities/monitoring.py
+++ b/python/smashbox/utilities/monitoring.py
@@ -1,0 +1,16 @@
+from smashbox.utilities import *
+
+# simple monitoring to grafana (disabled if not set in config)
+
+def push_to_monitoring(metric,value,timestamp=None):
+
+    monitoring_host=config.get('monitoring_host',None)
+    monitoring_port=config.get('monitoring_port',2003)
+
+    if not monitoring_host:
+        return
+
+    if not timestamp:
+        timestamp = time.time()
+
+    os.system("echo '%s %s %s' | nc %s %s"%(metric,value,timestamp,monitoring_host,monitoring_port))

--- a/python/smashbox/utilities/monitoring.py
+++ b/python/smashbox/utilities/monitoring.py
@@ -1,5 +1,8 @@
-from smashbox.utilities import *
-from smashbox.utilities import reflection
+from smashbox.utilities import reflection, config, os
+import smashbox.utilities
+
+def push_to_local_monitor(metric, value):
+    print metric, value
 
 def commit_to_monitoring(metric,value,timestamp=None):
     shared = reflection.getSharedObject()
@@ -17,28 +20,60 @@ def commit_to_monitoring(metric,value,timestamp=None):
     monitoring_points.append(monitoring_point)
     shared['monitoring_points'] = monitoring_points
 
-def push_to_monitoring(returncode):
+def push_to_monitoring(returncode, total_duration):
     shared = reflection.getSharedObject()
     if not 'monitoring_points' in shared.keys():
         return
 
+    monitoring_points = shared['monitoring_points']
     monitoring_type = config.get('monitoring_type', None)
-    if monitoring_type == 'cernbox':
-        monitoring_host = config.get('monitoring_host', None)
-        monitoring_port = config.get('monitoring_port', 2003)
+    if monitoring_type == 'prometheus':
+        monitoring_endpoint = config.get('endpoint', None)
+        release = config.get('owncloud', None)
+        client = config.get('client', None)
+        suite = config.get('suite', None)
+        build = config.get('build', None)
+        duration_label = config.get('duration_label', None)
+        queries_label = config.get('queries_label', None)
 
-        if not monitoring_host:
-            return
+        points_to_push = []
 
-        monitoring_points = shared['monitoring_points']
+        # total duration is default for jenkins if given
+        if duration_label is not None:
+            points_to_push.append('%s{owncloud=\\"%s\\",client=\\"%s\\",suite=\\"%s\\",build=\\"%s\\",exit=\\"%s\\"} %s'%(
+                duration_label,
+                release,
+                client,
+                suite,
+                build,
+                returncode,
+                total_duration))
+
+        # No. queries is default for jenkins if given
+        if queries_label is not None:
+            # TODO: add number of queries from log
+            no_queries = 0
+            points_to_push.append('%s{owncloud=\\"%s\\",client=\\"%s\\",suite=\\"%s\\",build=\\"%s\\",exit=\\"%s\\"} %s'%(
+                queries_label,
+                release,
+                client,
+                suite,
+                build,
+                returncode,
+                no_queries))
+
+        # Other points are not supported in jenkins yet
         for monitoring_point in monitoring_points:
-            timestamp = monitoring_point['timestamp']
-            if not timestamp:
-                timestamp = time.time()
+            continue
 
-            os.system("echo '%s %s %s' | nc %s %s" % (monitoring_point['metric'],  monitoring_point['value'], timestamp, monitoring_host, monitoring_port))
-    else:
-        monitoring_points = shared['monitoring_points']
+        # Push to monitoring all points to be pushed
+        for point_to_push in points_to_push:
+            cmd = "echo \"%s\" | curl --data-binary @- %s"%(point_to_push,monitoring_endpoint)
+            smashbox.utilities.log_info('Pushing to monitoring: %s'%cmd)
+            os.system(cmd)
+
+    elif monitoring_type == 'local':
         for monitoring_point in monitoring_points:
-            print monitoring_point['metric'], monitoring_point['value']
-        print "returncode", returncode
+            push_to_local_monitor(monitoring_point['metric'], monitoring_point['value'])
+        push_to_local_monitor("returncode", returncode)
+        push_to_local_monitor("elapsed", total_duration)


### PR DESCRIPTION
Generaly now anybody can add their own monitoring endpoints, and they will be "pushed" only when everything finished, knowing "final exit code", so if test finised with errors, and execution time without need for greping

 -[x] Added fixes in `bin/smash`and `corruption_test/run_nplusone_loop` from @moscicki
 -[x] Updated default chunking size to 10MB
 -[x] Added Monitoring Integration (`monitoring.py`) adding support for local monitor and jenkins export of number of queries and total duration by default of each test, and extended one of the tests `test_nplusone.py` with export of upload and download duration
 -[x] Extended README with Monitoring Integration

README: https://github.com/owncloud/smashbox/blob/e2aaa27c01dfd4888fea94f19fc925da76112ea0/README.md#monitoring-integration