### PR TITLE
Test shares with both old and new endpoint if possible by capability

### DIFF
--- a/etc/smashbox.conf.template
+++ b/etc/smashbox.conf.template
@@ -42,6 +42,7 @@ oc_root = 'owncloud'
 # webdav endpoint URI within the oc_server
 import os.path
 oc_webdav_endpoint = os.path.join(oc_root,'remote.php/webdav') # standard owncloud server
+new_oc_webdav_endpoint = os.path.join(oc_root,'remote.php/dav/files/') # new owncloud server > 10.0
 
 # target folder on the server (this may not be compatible with all tests)
 oc_server_folder = ''

--- a/etc/smashbox.conf.template
+++ b/etc/smashbox.conf.template
@@ -42,7 +42,6 @@ oc_root = 'owncloud'
 # webdav endpoint URI within the oc_server
 import os.path
 oc_webdav_endpoint = os.path.join(oc_root,'remote.php/webdav') # standard owncloud server
-new_oc_webdav_endpoint = os.path.join(oc_root,'remote.php/dav/files/') # new owncloud server > 10.0
 
 # target folder on the server (this may not be compatible with all tests)
 oc_server_folder = ''

--- a/lib/oc-tests/test_reshareDir.py
+++ b/lib/oc-tests/test_reshareDir.py
@@ -46,8 +46,31 @@ OCS_PERMISSION_ALL = 31
 
 filesizeKB = int(config.get('share_filesizeKB',10))
 
+# True => use new webdav endpoint (dav/files)
+# False => use old webdav endpoint (webdav)
+use_new_dav_endpoint = bool(config.get('use_new_dav_endpoint',True))
+
+testsets = [
+        {
+          'use_new_dav_endpoint':False
+        },
+        {
+          'use_new_dav_endpoint':True
+        }
+]
+
+def finish_if_not_capable():
+    # Finish the test if some of the prerequisites for this test are not satisfied
+    if compare_oc_version('10.0', '<') and use_new_dav_endpoint == True:
+        #Dont test for <= 9.1 with new endpoint, since it is not supported
+        logger.warn("Skipping test since webdav endpoint is not capable for this server version")
+        return True
+    return False
+
 @add_worker
 def setup(step):
+    if finish_if_not_capable():
+        return
 
     step (1, 'create test users')
     reset_owncloud_account(num_test_users=config.oc_number_test_users)
@@ -57,6 +80,8 @@ def setup(step):
 
 @add_worker
 def sharer(step):
+    if finish_if_not_capable():
+        return
 
     step (2, 'Create workdir')
     d = make_workdir()
@@ -76,7 +101,7 @@ def sharer(step):
     logger.info('md5_sharer: %s',shared['md5_sharer'])
 
     list_files(d)
-    run_ocsync(d,user_num=1)
+    run_ocsync(d,user_num=1, use_new_dav_endpoint=use_new_dav_endpoint)
     list_files(d)
 
     step (4, 'Sharer shares directory')
@@ -91,13 +116,15 @@ def sharer(step):
 
 @add_worker
 def shareeOne(step):
+    if finish_if_not_capable():
+        return
 
     step (2, 'Sharee One creates workdir')
     d = make_workdir()
 
     step (5, 'Sharee One syncs and validates directory exist')
 
-    run_ocsync(d,user_num=2)
+    run_ocsync(d,user_num=2, use_new_dav_endpoint=use_new_dav_endpoint)
     list_files(d)
 
     sharedDir = os.path.join(d,'localShareDir')
@@ -115,7 +142,9 @@ def shareeOne(step):
 
 @add_worker
 def shareeTwo(step):
-  
+    if finish_if_not_capable():
+        return
+
     step (2, 'Sharee Two creates workdir')
     d = make_workdir()
 
@@ -125,7 +154,7 @@ def shareeTwo(step):
 
     step (7, 'Sharee two validates share file')
 
-    run_ocsync(d,user_num=3)
+    run_ocsync(d,user_num=3, use_new_dav_endpoint=use_new_dav_endpoint)
     list_files(d)
 
     sharedFile = os.path.join(d,'TEST_FILE_USER_RESHARE.dat')

--- a/lib/oc-tests/test_shareLink.py
+++ b/lib/oc-tests/test_shareLink.py
@@ -148,7 +148,7 @@ def public_downloader_selected_single_files(step):
 
     shared = reflection.getSharedObject()
 
-    if compare_oc_version('9.1', '<='):
+    if compare_oc_version('10.0', '<'):
         url = oc_webdav_url(
             remote_folder=os.path.join(
                 'index.php', 's',
@@ -283,7 +283,7 @@ def public_downloader_selected_files(step):
     shared = reflection.getSharedObject()
 
 
-    if compare_oc_version('9.1', '<='):
+    if compare_oc_version('10.0', '<'):
         url = oc_webdav_url(
             remote_folder=os.path.join(
                 'index.php', 's',

--- a/lib/oc-tests/test_sharePermissions.py
+++ b/lib/oc-tests/test_sharePermissions.py
@@ -75,7 +75,7 @@ ALL_OPERATIONS = [
 
 # True => use new webdav endpoint (dav/files)
 # False => use old webdav endpoint (webdav)
-new_webdav_endpoint = bool(config.get('new_webdav_endpoint',True))
+use_new_dav_endpoint = bool(config.get('use_new_dav_endpoint',True))
 
 """
     Permission matrix parameters (they all default to False):
@@ -104,7 +104,7 @@ testsets = [
                 'rmdir',
             ]
         },
-        'new_webdav_endpoint': False
+        'use_new_dav_endpoint': False
     },
     {
         'sharePermissions_matrix': {
@@ -126,21 +126,21 @@ testsets = [
                 'rmdir',
             ]
         },
-        'new_webdav_endpoint': True
+        'use_new_dav_endpoint': True
     },
     {
         'sharePermissions_matrix': {
             'permission': OCS_PERMISSION_READ,
             'allowed_operations': []
         },
-        'new_webdav_endpoint': False
+        'use_new_dav_endpoint': False
     },
     {
         'sharePermissions_matrix': {
             'permission': OCS_PERMISSION_READ,
             'allowed_operations': []
         },
-        'new_webdav_endpoint': True
+        'use_new_dav_endpoint': True
     },
     {
         'sharePermissions_matrix': {
@@ -152,7 +152,7 @@ testsets = [
                 'mkdir',
             ]
         },
-        'new_webdav_endpoint': False
+        'use_new_dav_endpoint': False
     },
     {
         'sharePermissions_matrix': {
@@ -164,7 +164,7 @@ testsets = [
                 'mkdir',
             ]
         },
-        'new_webdav_endpoint': True
+        'use_new_dav_endpoint': True
     },
     {
         'sharePermissions_matrix': {
@@ -174,7 +174,7 @@ testsets = [
                 'rename',
             ]
         },
-        'new_webdav_endpoint': False
+        'use_new_dav_endpoint': False
     },
     {
         'sharePermissions_matrix': {
@@ -184,7 +184,7 @@ testsets = [
                 'rename',
             ]
         },
-        'new_webdav_endpoint': True
+        'use_new_dav_endpoint': True
     },
     {
         'sharePermissions_matrix': {
@@ -195,7 +195,7 @@ testsets = [
                 'rmdir',
             ]
         },
-        'new_webdav_endpoint': False
+        'use_new_dav_endpoint': False
     },
     {
         'sharePermissions_matrix': {
@@ -206,7 +206,7 @@ testsets = [
                 'rmdir',
             ]
         },
-        'new_webdav_endpoint': True
+        'use_new_dav_endpoint': True
     },
     {
         'sharePermissions_matrix': {
@@ -220,7 +220,7 @@ testsets = [
                 'mkdir',
             ]
         },
-        'new_webdav_endpoint': False
+        'use_new_dav_endpoint': False
     },
     {
         'sharePermissions_matrix': {
@@ -234,7 +234,7 @@ testsets = [
                 'mkdir',
             ]
         },
-        'new_webdav_endpoint': True
+        'use_new_dav_endpoint': True
     },
     {
         'sharePermissions_matrix': {
@@ -254,7 +254,7 @@ testsets = [
                 'rmdir',
             ]
         },
-        'new_webdav_endpoint': False
+        'use_new_dav_endpoint': False
     },
     {
         'sharePermissions_matrix': {
@@ -274,7 +274,7 @@ testsets = [
                 'rmdir',
             ]
         },
-        'new_webdav_endpoint': True
+        'use_new_dav_endpoint': True
     },
     {
         'sharePermissions_matrix': {
@@ -287,7 +287,7 @@ testsets = [
                 'rmdir',
             ]
         },
-        'new_webdav_endpoint': False
+        'use_new_dav_endpoint': False
     },
     {
         'sharePermissions_matrix': {
@@ -300,7 +300,7 @@ testsets = [
                 'rmdir',
             ]
         },
-        'new_webdav_endpoint': True
+        'use_new_dav_endpoint': True
     }
 ]
 
@@ -309,9 +309,10 @@ permission_matrix = config.get('sharePermissions_matrix', testsets[0]['sharePerm
 SHARED_DIR_NAME = 'shared-dir'
 
 def finish_if_not_capable():
-    if compare_oc_version('10.0', '<') and new_webdav_endpoint == True:
+    # Finish the test if some of the prerequisites for this test are not satisfied
+    if compare_oc_version('10.0', '<') and use_new_dav_endpoint == True:
         #Dont test for <= 9.1 with new endpoint, since it is not supported
-        logger.warn("Skipping test since webdav endpoint not capable")
+        logger.warn("Skipping test since webdav endpoint is not capable for this server version")
         return True
     return False
 
@@ -357,7 +358,7 @@ def owner_worker(step):
     createfile(os.path.join(d, SHARED_DIR_NAME, 'delete_this_dir', 'stuff.dat'),'0',count=1000,bs=1)
 
     list_files(d)
-    run_ocsync(d, user_num=1, use_new_dav_endpoint=new_webdav_endpoint)
+    run_ocsync(d, user_num=1, use_new_dav_endpoint=use_new_dav_endpoint)
     list_files(d)
 
     step (4, 'Shares folder with recipient')
@@ -379,10 +380,10 @@ def recipient_worker(step):
     step (5, 'Check permission enforcement for every operation')
 
     list_files(d)
-    run_ocsync(d, user_num=2, use_new_dav_endpoint=new_webdav_endpoint)
+    run_ocsync(d, user_num=2, use_new_dav_endpoint=use_new_dav_endpoint)
     list_files(d)
 
-    oc = get_oc_api(use_new_dav_endpoint=new_webdav_endpoint)
+    oc = get_oc_api(use_new_dav_endpoint=use_new_dav_endpoint)
     user2 = "%s%i" % (config.oc_account_name, 2)
     oc.login(user2, config.oc_account_password)
 

--- a/lib/oc-tests/test_uploadFiles.py
+++ b/lib/oc-tests/test_uploadFiles.py
@@ -48,26 +48,61 @@ filesizeKB = int(config.get('test_filesizeKB',10))
 sharePermissions = config.get('test_sharePermissions', OCS_PERMISSION_ALL)
 numFilesToCreate = config.get('test_numFilesToCreate', 1)
 
+# True => use new webdav endpoint (dav/files)
+# False => use old webdav endpoint (webdav)
+use_new_dav_endpoint = bool(config.get('use_new_dav_endpoint',True))
+
 testsets = [
     {
         'test_sharePermissions':OCS_PERMISSION_ALL,
         'test_numFilesToCreate':50,
-        'test_filesizeKB':20000
+        'test_filesizeKB':20000,
+        'use_new_dav_endpoint':True
+    },
+    {
+        'test_sharePermissions':OCS_PERMISSION_ALL,
+        'test_numFilesToCreate':50,
+        'test_filesizeKB':20000,
+        'use_new_dav_endpoint':False
     },
     {
         'test_sharePermissions':OCS_PERMISSION_ALL,
         'test_numFilesToCreate':500,
-        'test_filesizeKB':2000
+        'test_filesizeKB':2000,
+        'use_new_dav_endpoint':True
+    },
+    {
+        'test_sharePermissions':OCS_PERMISSION_ALL,
+        'test_numFilesToCreate':500,
+        'test_filesizeKB':2000,
+        'use_new_dav_endpoint':False
     },
     {
         'test_sharePermissions':OCS_PERMISSION_READ | OCS_PERMISSION_CREATE | OCS_PERMISSION_UPDATE,
         'test_numFilesToCreate':50,
-        'test_filesizeKB':20000
+        'test_filesizeKB':20000,
+        'use_new_dav_endpoint':True
+    },
+    {
+        'test_sharePermissions':OCS_PERMISSION_READ | OCS_PERMISSION_CREATE | OCS_PERMISSION_UPDATE,
+        'test_numFilesToCreate':50,
+        'test_filesizeKB':20000,
+        'use_new_dav_endpoint':False
     },
 ]
 
+def finish_if_not_capable():
+    # Finish the test if some of the prerequisites for this test are not satisfied
+    if compare_oc_version('10.0', '<') and use_new_dav_endpoint == True:
+        #Dont test for <= 9.1 with new endpoint, since it is not supported
+        logger.warn("Skipping test since webdav endpoint is not capable for this server version")
+        return True
+    return False
+
 @add_worker
 def setup(step):
+    if finish_if_not_capable():
+        return
 
     step (1, 'create test users')
     reset_owncloud_account(num_test_users=config.oc_number_test_users)
@@ -77,6 +112,8 @@ def setup(step):
 
 @add_worker
 def sharer(step):
+    if finish_if_not_capable():
+        return
 
     step (2,'Create workdir')
     d = make_workdir()
@@ -88,7 +125,7 @@ def sharer(step):
     localDir = make_workdir(dirName)
 
     list_files(d)
-    run_ocsync(d,user_num=1)
+    run_ocsync(d,user_num=1, use_new_dav_endpoint=use_new_dav_endpoint)
     list_files(d)
 
     step (4,'Sharer shares directory')
@@ -105,7 +142,7 @@ def sharer(step):
 
     step (7, 'Sharer validates newly added files')
 
-    run_ocsync(d,user_num=1)
+    run_ocsync(d,user_num=1, use_new_dav_endpoint=use_new_dav_endpoint)
 
     list_files(d+'/localShareDir')
     checkFilesExist(d) 
@@ -114,13 +151,15 @@ def sharer(step):
 
 @add_worker
 def shareeOne(step):
+    if finish_if_not_capable():
+        return
 
     step (2, 'Sharee One creates workdir')
     d = make_workdir()
 
     step (5,'Sharee One syncs and validates directory exist')
 
-    run_ocsync(d,user_num=2)
+    run_ocsync(d,user_num=2, use_new_dav_endpoint=use_new_dav_endpoint)
     list_files(d)
 
     sharedDir = os.path.join(d,'localShareDir')
@@ -137,7 +176,7 @@ def shareeOne(step):
         filename = "%s%i%s" % ('localShareDir/TEST_FILE_NEW_USER_SHARE_',i,'.dat')
         createfile(os.path.join(d,filename),'0',count=1000,bs=filesizeKB)
 
-    run_ocsync(d,user_num=2)
+    run_ocsync(d,user_num=2, use_new_dav_endpoint=use_new_dav_endpoint)
 
     list_files(d+'/localShareDir')
     checkFilesExist(d) 
@@ -146,6 +185,8 @@ def shareeOne(step):
 
 @add_worker
 def shareeTwo(step):
+    if finish_if_not_capable():
+        return
   
     step (2, 'Sharee Two creates workdir')
     d = make_workdir()
@@ -156,7 +197,7 @@ def shareeTwo(step):
 
     step (5, 'Sharee two syncs and validates directory exists')
 
-    run_ocsync(d,user_num=3)
+    run_ocsync(d,user_num=3, use_new_dav_endpoint=use_new_dav_endpoint)
     list_files(d)
 
     sharedDir = os.path.join(d,'localShareDir')
@@ -165,7 +206,7 @@ def shareeTwo(step):
 
     step (7, 'Sharee two validates new files exist')
 
-    run_ocsync(d,user_num=3)
+    run_ocsync(d,user_num=3, use_new_dav_endpoint=use_new_dav_endpoint)
 
     list_files(d+'/localShareDir')
     checkFilesExist(d) 

--- a/lib/owncloud/test_sharePropagationGroups.py
+++ b/lib/owncloud/test_sharePropagationGroups.py
@@ -47,14 +47,14 @@ import operator as op
 
 # True => use new webdav endpoint (dav/files)
 # False => use old webdav endpoint (webdav)
-new_webdav_endpoint = bool(config.get('new_webdav_endpoint',True))
+use_new_dav_endpoint = bool(config.get('use_new_dav_endpoint',True))
 
 testsets = [
         {
-          'new_webdav_endpoint':False
+          'use_new_dav_endpoint':False
         },
         {
-          'new_webdav_endpoint':True
+          'use_new_dav_endpoint':True
         }
 ]
 
@@ -93,7 +93,7 @@ def get_client_etags(clients):
 
 def run_group_ocsync(d, group_name):
     for usernum in group_map[group_name]:
-        run_ocsync(os.path.join(d, str(usernum)), user_num=usernum, use_new_dav_endpoint=new_webdav_endpoint)
+        run_ocsync(os.path.join(d, str(usernum)), user_num=usernum, use_new_dav_endpoint=use_new_dav_endpoint)
 
 def parse_worker_number(worker_name):
     match = re.search(r'(\d+)$', worker_name)
@@ -103,9 +103,10 @@ def parse_worker_number(worker_name):
         return None
 
 def finish_if_not_capable():
-    if compare_oc_version('10.0', '<') and new_webdav_endpoint == True:
+    # Finish the test if some of the prerequisites for this test are not satisfied
+    if compare_oc_version('10.0', '<') and use_new_dav_endpoint == True:
         #Dont test for <= 9.1 with new endpoint, since it is not supported
-        logger.warn("Skipping test since webdav endpoint not capable")
+        logger.warn("Skipping test since webdav endpoint is not capable for this server version")
         return True
     return False
 
@@ -143,9 +144,9 @@ def owner(step):
     d = make_workdir()
 
     mkdir(os.path.join(d, 'test', 'sub'))
-    run_ocsync(d, user_num=1, use_new_dav_endpoint=new_webdav_endpoint)
+    run_ocsync(d, user_num=1, use_new_dav_endpoint=use_new_dav_endpoint)
 
-    client = get_oc_api(use_new_dav_endpoint=new_webdav_endpoint)
+    client = get_oc_api(use_new_dav_endpoint=use_new_dav_endpoint)
     client.login(user, config.oc_account_password)
     # make sure folder is shared
     group1 = get_group_name(1)
@@ -160,7 +161,7 @@ def owner(step):
 
     step(3, 'Upload file')
     createfile(os.path.join(d, 'test', 'test.txt'), '1', count=1000, bs=10)
-    run_ocsync(d, user_num=1, use_new_dav_endpoint=new_webdav_endpoint)
+    run_ocsync(d, user_num=1, use_new_dav_endpoint=use_new_dav_endpoint)
 
     step(4, 'Verify etag propagation')
     root_etag2 = client.file_info('/').get_etag()
@@ -225,7 +226,7 @@ def recipients(step):
 
     clients = []
     for usernum in group_map[group]:
-        client = get_oc_api(use_new_dav_endpoint=new_webdav_endpoint)
+        client = get_oc_api(use_new_dav_endpoint=use_new_dav_endpoint)
         client.login(get_account_name(usernum), config.oc_account_password)
         clients.append(client)
 
@@ -299,7 +300,7 @@ def recipients(step):
 def recipient_3(step):
     if finish_if_not_capable():
         return
-    
+
     groupnum = parse_worker_number(reflection.getProcessName())
     group = get_group_name(groupnum)
 
@@ -312,7 +313,7 @@ def recipient_3(step):
 
     clients = []
     for usernum in group_map[group]:
-        client = get_oc_api(use_new_dav_endpoint=new_webdav_endpoint)
+        client = get_oc_api(use_new_dav_endpoint=use_new_dav_endpoint)
         client.login(get_account_name(usernum), config.oc_account_password)
         clients.append(client)
 

--- a/lib/owncloud/test_sharePropagationInsideGroups.py
+++ b/lib/owncloud/test_sharePropagationInsideGroups.py
@@ -52,14 +52,14 @@ import operator as op
 
 # True => use new webdav endpoint (dav/files)
 # False => use old webdav endpoint (webdav)
-new_webdav_endpoint = bool(config.get('new_webdav_endpoint',True))
+use_new_dav_endpoint = bool(config.get('use_new_dav_endpoint',True))
 
 testsets = [
         {
-          'new_webdav_endpoint':False
+          'use_new_dav_endpoint':False
         },
         {
-          'new_webdav_endpoint':True
+          'use_new_dav_endpoint':True
         }
 ]
 
@@ -99,12 +99,13 @@ def get_client_etags(clients, path):
 
 def run_group_ocsync(d, group_name):
     for usernum in group_map[group_name]:
-        run_ocsync(os.path.join(d, str(usernum)), user_num=usernum, use_new_dav_endpoint=new_webdav_endpoint)
+        run_ocsync(os.path.join(d, str(usernum)), user_num=usernum, use_new_dav_endpoint=use_new_dav_endpoint)
 
 def finish_if_not_capable():
-    if compare_oc_version('10.0', '<') and new_webdav_endpoint == True:
+    # Finish the test if some of the prerequisites for this test are not satisfied
+    if compare_oc_version('10.0', '<') and use_new_dav_endpoint == True:
         #Dont test for <= 9.1 with new endpoint, since it is not supported
-        logger.warn("Skipping test since webdav endpoint not capable")
+        logger.warn("Skipping test since webdav endpoint is not capable for this server version")
         return True
     return False
 
@@ -142,9 +143,9 @@ def owner(step):
     d = make_workdir()
 
     mkdir(os.path.join(d, 'test', 'sub'))
-    run_ocsync(d, user_num=1, use_new_dav_endpoint=new_webdav_endpoint)
+    run_ocsync(d, user_num=1, use_new_dav_endpoint=use_new_dav_endpoint)
 
-    client = get_oc_api(use_new_dav_endpoint=new_webdav_endpoint)
+    client = get_oc_api(use_new_dav_endpoint=use_new_dav_endpoint)
     client.login(user, config.oc_account_password)
     # make sure folder is shared
     group1 = get_group_name(1)
@@ -161,7 +162,7 @@ def owner(step):
 
     step(5, 'Upload to /test')
     createfile(os.path.join(d, 'test', 'test2.txt'), '2', count=1000, bs=10)
-    run_ocsync(d, user_num=1, use_new_dav_endpoint=new_webdav_endpoint)
+    run_ocsync(d, user_num=1, use_new_dav_endpoint=use_new_dav_endpoint)
 
     step(6, 'verify etag propagation')
     root_etag2 = client.file_info('/').get_etag()
@@ -175,7 +176,7 @@ def owner(step):
 
     step(9, 'Upload to /test/sub')
     createfile(os.path.join(d, 'test', 'sub', 'test4.txt'), '4', count=1000, bs=10)
-    run_ocsync(d, user_num=1, use_new_dav_endpoint=new_webdav_endpoint)
+    run_ocsync(d, user_num=1, use_new_dav_endpoint=use_new_dav_endpoint)
 
     step(10, 'verify etag propagation')
     root_etag4 = client.file_info('/').get_etag()
@@ -226,7 +227,7 @@ def recipient1(step):
 
     clients = []
     for usernum in group_map[group]:
-        client = get_oc_api(use_new_dav_endpoint=new_webdav_endpoint)
+        client = get_oc_api(use_new_dav_endpoint=use_new_dav_endpoint)
         client.login(get_account_name(usernum), config.oc_account_password)
         clients.append(client)
 
@@ -299,7 +300,7 @@ def recipient2(step):
 
     clients = []
     for usernum in group_map[group]:
-        client = get_oc_api(use_new_dav_endpoint=new_webdav_endpoint)
+        client = get_oc_api(use_new_dav_endpoint=use_new_dav_endpoint)
         client.login(get_account_name(usernum), config.oc_account_password)
         clients.append(client)
 
@@ -385,7 +386,7 @@ def recipient3(step):
 
     clients = []
     for usernum in group_map[group]:
-        client = get_oc_api(use_new_dav_endpoint=new_webdav_endpoint)
+        client = get_oc_api(use_new_dav_endpoint=use_new_dav_endpoint)
         client.login(get_account_name(usernum), config.oc_account_password)
         clients.append(client)
 
@@ -452,7 +453,7 @@ def recipient4(step):
 
     clients = []
     for usernum in group_map[group]:
-        client = get_oc_api(use_new_dav_endpoint=new_webdav_endpoint)
+        client = get_oc_api(use_new_dav_endpoint=use_new_dav_endpoint)
         client.login(get_account_name(usernum), config.oc_account_password)
         clients.append(client)
 

--- a/lib/test_basicSync.py
+++ b/lib/test_basicSync.py
@@ -29,16 +29,16 @@ rmLocalStateDB = bool(config.get('basicSync_rmLocalStateDB',False))
 
 # True => use new webdav endpoint (dav/files)
 # False => use old webdav endpoint (webdav)
-new_webdav_endpoint = bool(config.get('new_webdav_endpoint',True))
+use_new_dav_endpoint = bool(config.get('use_new_dav_endpoint',True))
 
 testsets = [
         { 'basicSync_filesizeKB': 1, 
           'basicSync_rmLocalStateDB':False,
-          'new_webdav_endpoint':True
+          'use_new_dav_endpoint':True
         },
         { 'basicSync_filesizeKB': 1,
           'basicSync_rmLocalStateDB':False,
-          'new_webdav_endpoint':False
+          'use_new_dav_endpoint':False
         },
         { 'basicSync_filesizeKB': 5000, 
           'basicSync_rmLocalStateDB':False
@@ -48,20 +48,20 @@ testsets = [
         },
         { 'basicSync_filesizeKB': 50000, 
           'basicSync_rmLocalStateDB':False,
-          'new_webdav_endpoint':True
+          'use_new_dav_endpoint':True
         },
         { 'basicSync_filesizeKB': 50000,
           'basicSync_rmLocalStateDB':False,
-          'new_webdav_endpoint':False
+          'use_new_dav_endpoint':False
         },
 
         { 'basicSync_filesizeKB': 1, 
           'basicSync_rmLocalStateDB':True,
-          'new_webdav_endpoint':True
+          'use_new_dav_endpoint':True
         },
         { 'basicSync_filesizeKB': 1,
           'basicSync_rmLocalStateDB':True,
-          'new_webdav_endpoint':False
+          'use_new_dav_endpoint':False
         },
         { 'basicSync_filesizeKB': 5000, 
           'basicSync_rmLocalStateDB':True
@@ -71,11 +71,11 @@ testsets = [
         },
         { 'basicSync_filesizeKB': 50000, 
           'basicSync_rmLocalStateDB':True,
-          'new_webdav_endpoint':True
+          'use_new_dav_endpoint':True
         },
         { 'basicSync_filesizeKB': 50000,
           'basicSync_rmLocalStateDB':True,
-          'new_webdav_endpoint':False
+          'use_new_dav_endpoint':False
         }
 ]
 
@@ -115,9 +115,10 @@ def expect_no_conflict_files(d):
     expect_conflict_files(d,[])
 
 def finish_if_not_capable():
-    if compare_oc_version('10.0', '<') and new_webdav_endpoint == True:
+    # Finish the test if some of the prerequisites for this test are not satisfied
+    if compare_oc_version('10.0', '<') and use_new_dav_endpoint == True:
         #Dont test for <= 9.1 with new endpoint, since it is not supported
-        logger.warn("Skipping test since webdav endpoint not capable")
+        logger.warn("Skipping test since webdav endpoint is not capable for this server version")
         return True
     return False
     
@@ -151,11 +152,11 @@ def creator(step):
     logger.info('md5_creator: %s',shared['md5_creator'])
 
     list_files(d)
-    run_ocsync(d, use_new_dav_endpoint=new_webdav_endpoint)
+    run_ocsync(d, use_new_dav_endpoint=use_new_dav_endpoint)
     list_files(d)
 
     step(7,'download the repository')
-    run_ocsync(d,n=3, use_new_dav_endpoint=new_webdav_endpoint)
+    run_ocsync(d,n=3, use_new_dav_endpoint=use_new_dav_endpoint)
 
     step(8,'final check')
 
@@ -170,7 +171,7 @@ def winner(step):
     step(2,'initial sync')
 
     d = make_workdir()
-    run_ocsync(d, use_new_dav_endpoint=new_webdav_endpoint)
+    run_ocsync(d, use_new_dav_endpoint=use_new_dav_endpoint)
 
     step(3,'modify locally and sync to server')
 
@@ -189,11 +190,11 @@ def winner(step):
     shared['md5_winner'] = md5sum(os.path.join(d,'TEST_FILE_ADDED_WINNER.dat'))
     logger.info('md5_winner: %s',shared['md5_winner'])
 
-    run_ocsync(d, use_new_dav_endpoint=new_webdav_endpoint)
+    run_ocsync(d, use_new_dav_endpoint=use_new_dav_endpoint)
 
     step(5,'final sync')
 
-    run_ocsync(d,n=3, use_new_dav_endpoint=new_webdav_endpoint)
+    run_ocsync(d,n=3, use_new_dav_endpoint=use_new_dav_endpoint)
 
     step(8,'final check')
 
@@ -211,7 +212,7 @@ def loser(step):
     step(2,'initial sync')
 
     d = make_workdir()
-    run_ocsync(d, use_new_dav_endpoint=new_webdav_endpoint)
+    run_ocsync(d, use_new_dav_endpoint=use_new_dav_endpoint)
 
     step(4,'modify locally and sync to the server')
 
@@ -240,10 +241,10 @@ def loser(step):
     if rmLocalStateDB:
         remove_db_in_folder(d)
 
-    run_ocsync(d,n=3, use_new_dav_endpoint=new_webdav_endpoint) # conflict file will be synced to the server but it requires more than one sync run
+    run_ocsync(d,n=3, use_new_dav_endpoint=use_new_dav_endpoint) # conflict file will be synced to the server but it requires more than one sync run
 
     step(6,'final sync')
-    run_ocsync(d, use_new_dav_endpoint=new_webdav_endpoint)
+    run_ocsync(d, use_new_dav_endpoint=use_new_dav_endpoint)
 
     step(8,'final check')
 
@@ -265,7 +266,7 @@ def checker(step):
 
     step(7,'download the repository for final verification')
     d = make_workdir()
-    run_ocsync(d,n=3, use_new_dav_endpoint=new_webdav_endpoint)
+    run_ocsync(d,n=3, use_new_dav_endpoint=use_new_dav_endpoint)
 
     step(8,'final check')
 

--- a/lib/test_concurrentDirRemove.py
+++ b/lib/test_concurrentDirRemove.py
@@ -15,19 +15,37 @@ nfiles = int(config.get('concurrentRemoveDir_nfiles',10))
 filesizeKB = int(config.get('concurrentRemoveDir_filesizeKB',9000))
 delaySeconds = int(config.get('concurrentRemoveDir_delaySeconds',3)) # if delaySeconds > 0 then remover waits; else the adder waits;
 
+# True => use new webdav endpoint (dav/files)
+# False => use old webdav endpoint (webdav)
+use_new_dav_endpoint = bool(config.get('use_new_dav_endpoint',True))
+
 testsets = [ 
     {'concurrentRemoveDir_nfiles':3,
      'concurrentRemoveDir_filesizeKB':10000,
-     'concurrentRemoveDir_delaySeconds':5 },  # removing the directory while a large file is chunk-uploaded
+     'concurrentRemoveDir_delaySeconds':5,
+     'use_new_dav_endpoint': True },  # removing the directory while a large file is chunk-uploaded
+    {'concurrentRemoveDir_nfiles':3,
+     'concurrentRemoveDir_filesizeKB':10000,
+     'concurrentRemoveDir_delaySeconds':5,
+     'use_new_dav_endpoint': False },  # removing the directory while a large file is chunk-uploaded
 
     {'concurrentRemoveDir_nfiles':40,
      'concurrentRemoveDir_filesizeKB':9000,
-     'concurrentRemoveDir_delaySeconds':5 }, # removing the directory while lots of smaller files are uploaded
+     'concurrentRemoveDir_delaySeconds':5,
+     'use_new_dav_endpoint': True }, # removing the directory while lots of smaller files are uploaded
+    {'concurrentRemoveDir_nfiles': 40,
+     'concurrentRemoveDir_filesizeKB': 9000,
+     'concurrentRemoveDir_delaySeconds': 5,
+     'use_new_dav_endpoint': False},  # removing the directory while lots of smaller files are uploaded
 
     {'concurrentRemoveDir_nfiles':5,
      'concurrentRemoveDir_filesizeKB':15000,
-     'concurrentRemoveDir_delaySeconds':-5 } # removing the directory before files are uploaded
-
+     'concurrentRemoveDir_delaySeconds':-5,
+     'use_new_dav_endpoint': True }, # removing the directory before files are uploaded
+    {'concurrentRemoveDir_nfiles':5,
+     'concurrentRemoveDir_filesizeKB':15000,
+     'concurrentRemoveDir_delaySeconds':-5,
+     'use_new_dav_endpoint': False }, # removing the directory before files are uploaded
     ]
 
 import time
@@ -36,8 +54,19 @@ import tempfile
 from smashbox.utilities import *
 from smashbox.utilities.hash_files import *
 
+def finish_if_not_capable():
+    # Finish the test if some of the prerequisites for this test are not satisfied
+    if compare_oc_version('10.0', '<') and use_new_dav_endpoint == True:
+        #Dont test for <= 9.1 with new endpoint, since it is not supported
+        logger.warn("Skipping test since webdav endpoint is not capable for this server version")
+        return True
+    return False
+
 @add_worker
 def creator(step):
+    if finish_if_not_capable():
+        return
+
     reset_owncloud_account()
     reset_rundir()
 
@@ -45,19 +74,21 @@ def creator(step):
     d = make_workdir()
     d2 = os.path.join(d,'subdir')
     mkdir(d2)
-    run_ocsync(d)
+    run_ocsync(d, use_new_dav_endpoint=use_new_dav_endpoint)
 
     step(5,'final check')
-    run_ocsync(d)
+    run_ocsync(d, use_new_dav_endpoint=use_new_dav_endpoint)
     final_check(d)
 
     
 @add_worker
 def adder(step):
+    if finish_if_not_capable():
+        return
     
     step(2,'sync the empty directory created by the creator')
     d = make_workdir()
-    run_ocsync(d)
+    run_ocsync(d, use_new_dav_endpoint=use_new_dav_endpoint)
 
     step(3,'locally create content in the subdirectory')
     d2 = os.path.join(d,'subdir')
@@ -68,17 +99,20 @@ def adder(step):
     step(4,'sync the added files in parallel')
     if delaySeconds<0:
         sleep(-delaySeconds)
-    run_ocsync(d)
+    run_ocsync(d, use_new_dav_endpoint=use_new_dav_endpoint)
 
     step(5,'final check')
-    run_ocsync(d)
+    run_ocsync(d, use_new_dav_endpoint=use_new_dav_endpoint)
 
 
 @add_worker
 def remover(step):
+    if finish_if_not_capable():
+        return
+
     step(2,'sync the empty directory created by the creator')
     d = make_workdir()
-    run_ocsync(d)
+    run_ocsync(d, use_new_dav_endpoint=use_new_dav_endpoint)
 
     step(3,'locally remove subdir')
     d2 = os.path.join(d,'subdir')
@@ -87,18 +121,20 @@ def remover(step):
     step(4,'sync the removed subdir in parallel')
     if delaySeconds>0:
         sleep(delaySeconds)
-    run_ocsync(d)
+    run_ocsync(d, use_new_dav_endpoint=use_new_dav_endpoint)
 
     step(5,'final check')
-    run_ocsync(d)
+    run_ocsync(d, use_new_dav_endpoint=use_new_dav_endpoint)
     final_check(d)
 
 @add_worker
 def checker(step):
+    if finish_if_not_capable():
+        return
 
     step(5,'sync the final state of the repository into a fresh local folder')
     d = make_workdir()
-    run_ocsync(d)
+    run_ocsync(d, use_new_dav_endpoint=use_new_dav_endpoint)
 
     final_check(d)
 


### PR DESCRIPTION
I have found out why https://jenkins.owncloud.org/view/smashbox/ tests are failing -> it is because of old endpoint there @DeepDiver1975 @PVince81 

Issues are present only for versions 8.2, 9.0, 9.1 -> works for 10.0 (maybe backport needed?)

- New Endpoint does not send ETag for HomeFolder (so called '/'), while old does -> also adjusted test in case we dont want to backport https://github.com/owncloud/smashbox/tree/fix_propagation_groups

- New Endpoint has issue with moving received shares to another directory, which is not a case for 10.0. Seems needed backport

Now smashbox will test both old and new endpoint for sharing tests. 