### PR TITLE
Reduce amount of files in files_upload test to avoid objectstore errors in testing infra

### DIFF
--- a/lib/oc-tests/test_uploadFiles.py
+++ b/lib/oc-tests/test_uploadFiles.py
@@ -55,37 +55,25 @@ use_new_dav_endpoint = bool(config.get('use_new_dav_endpoint',True))
 testsets = [
     {
         'test_sharePermissions':OCS_PERMISSION_ALL,
-        'test_numFilesToCreate':50,
+        'test_numFilesToCreate':5,
         'test_filesizeKB':20000,
         'use_new_dav_endpoint':True
     },
     {
         'test_sharePermissions':OCS_PERMISSION_ALL,
-        'test_numFilesToCreate':50,
+        'test_numFilesToCreate':5,
         'test_filesizeKB':20000,
-        'use_new_dav_endpoint':False
-    },
-    {
-        'test_sharePermissions':OCS_PERMISSION_ALL,
-        'test_numFilesToCreate':500,
-        'test_filesizeKB':2000,
-        'use_new_dav_endpoint':True
-    },
-    {
-        'test_sharePermissions':OCS_PERMISSION_ALL,
-        'test_numFilesToCreate':500,
-        'test_filesizeKB':2000,
         'use_new_dav_endpoint':False
     },
     {
         'test_sharePermissions':OCS_PERMISSION_READ | OCS_PERMISSION_CREATE | OCS_PERMISSION_UPDATE,
-        'test_numFilesToCreate':50,
+        'test_numFilesToCreate':5,
         'test_filesizeKB':20000,
         'use_new_dav_endpoint':True
     },
     {
         'test_sharePermissions':OCS_PERMISSION_READ | OCS_PERMISSION_CREATE | OCS_PERMISSION_UPDATE,
-        'test_numFilesToCreate':50,
+        'test_numFilesToCreate':5,
         'test_filesizeKB':20000,
         'use_new_dav_endpoint':False
     },


### PR DESCRIPTION
I cannot reproduce the errors appearing in owncloud testing infrastructure (shared) when I try it locally.  

It happens with OLD ENDPOINT
```
SUMMARY:smash.:running /var/www/src/smashbox/test_uploadFiles.py in /smashdir/test_uploadFiles as test_uploadFiles testset #5 {'use_new_dav_endpoint': False, 'test_filesizeKB': 20000, 'test_numFilesToCreate': 50, 'test_sharePermissions': 7}
```

Smashbox error is

```
2018-09-18 02:55:00,664 - ERROR - sharer - File /smashdir/test_uploadFiles/sharer/localShareDir/TEST_FILE_NEW_USER_SHARE_4.dat should exist error_check(os.path.exists(sharedFile), "File %s should exist" %sharedFile) failed in checkFilesExist() ["/var/www/src/smashbox/test_uploadFiles.py" at line 229]
```

Storage/Server exception is 

```
\"Exception\":\"Sabre\\\\DAV\\\\Exception\",\"Message\":\"An exception occurred while uploading parts to a multipart upload. The following parts had errors:\\n- Part 1: Error executing \\\"UploadPart\\\" on \\\"http:\\\/\\\/scality:8000\\\/owncloud\\\/urn%3Aoid%3A444?partNumber=1&uploadId=7ac4d725ec6948f3a64643bb4a0696ba\\\"; AWS HTTP error: Error creating resource: [message] fopen(http:\\\/\\\/scality:8000\\\/owncloud\\\/urn%3Aoid%3A444?partNumber=1&amp;uploadId=7ac4d725ec6948f3a64643bb4a0696ba): failed to open stream: HTTP request failed! \\n[file] \\\/mnt\\\/data\\\/apps\\\/files_primary_s3\\\/vendor\\\/guzzlehttp\\\/ringphp\\\/src\\\/Client\\\/StreamHandler.php\\n[line] 406\\n\",\"Code\":0,\"Trace\":\"#0 \\\/var\\\/www\\\/owncloud\\\/apps\\\/dav\\\/lib\\\/Connector\\\/Sabre\\\/File.php(598): OCA\\\\DAV\\\\Connector\\\\Sabre\\\\File->convertToSabreException(Object(Aws\\\\S3\\\\Exception\\\\S3MultipartUploadException))\\n#1 \\\/var\\\/www\\\/owncloud\\\/apps\\\/dav\\\/lib\\\/Connector\\\/Sabre\\\/File.php(152): OCA\\\\DAV\\\\Connector\\\\Sabre\\\\File->createFileChunked(Resource id #71)
```

Corresponding timeout error below

```
{"name":"S3","bucketName":"owncloud","objectKey":"urn:oid:443","bytesReceived":5242880,"bodyLength":5242880,"rawError":{"code":"ETIMEDOUT","info":"operation put timed out"},"error":"Callback function \"bound _call\" timed out.","errorStack":"Error: Callback function \"bound _call\" timed out.\n    at Timeout.timeoutCallback [as _onTimeout] (/usr/src/app/node_modules/arsenal/node_modules/async/dist/async.js:4724:21)\n    at ontimeout (timers.js:386:11)\n    at tryOnTimeout (timers.js:250:5)\n    at Timer.listOnTimeout (timers.js:214:5)","t
```

The errors seem transient, CC @patrickjahns @DeepDiver1975 