### PR TITLE
Skip old webdav tests on client cmd version 3.0

### DIFF
--- a/lib/oc-tests/test_reshareDir.py
+++ b/lib/oc-tests/test_reshareDir.py
@@ -65,6 +65,10 @@ def finish_if_not_capable():
         #Dont test for <= 9.1 with new endpoint, since it is not supported
         logger.warn("Skipping test since webdav endpoint is not capable for this server version")
         return True
+    if compare_client_version('3.0', '>=') and use_new_dav_endpoint == False:
+        # Don't test for client version >= 3.0 with old endpoint, since it is not supported
+        logger.warn("Skipping test since old webdav endpoint is not support for this client version")
+        return True
     return False
 
 @add_worker

--- a/lib/oc-tests/test_shareDir.py
+++ b/lib/oc-tests/test_shareDir.py
@@ -109,6 +109,10 @@ def finish_if_not_capable():
         #Dont test for <= 9.1 with new endpoint, since it is not supported
         logger.warn("Skipping test since webdav endpoint is not capable for this server version")
         return True
+    if compare_client_version('3.0', '>=') and use_new_dav_endpoint == False:
+        # Don't test for client version >= 3.0 with old endpoint, since it is not supported
+        logger.warn("Skipping test since old webdav endpoint is not support for this client version")
+        return True
     return False
 
 @add_worker

--- a/lib/oc-tests/test_shareFile.py
+++ b/lib/oc-tests/test_shareFile.py
@@ -107,6 +107,10 @@ def finish_if_not_capable():
         #Dont test for <= 9.1 with new endpoint, since it is not supported
         logger.warn("Skipping test since webdav endpoint is not capable for this server version")
         return True
+    if compare_client_version('3.0', '>=') and use_new_dav_endpoint == False:
+        # Don't test for client version >= 3.0 with old endpoint, since it is not supported
+        logger.warn("Skipping test since old webdav endpoint is not support for this client version")
+        return True
     return False
 
 @add_worker

--- a/lib/oc-tests/test_shareGroup.py
+++ b/lib/oc-tests/test_shareGroup.py
@@ -100,6 +100,10 @@ def finish_if_not_capable():
         #Dont test for <= 9.1 with new endpoint, since it is not supported
         logger.warn("Skipping test since webdav endpoint is not capable for this server version")
         return True
+    if compare_client_version('3.0', '>=') and use_new_dav_endpoint == False:
+        # Don't test for client version >= 3.0 with old endpoint, since it is not supported
+        logger.warn("Skipping test since old webdav endpoint is not support for this client version")
+        return True
     return False
 
 @add_worker

--- a/lib/oc-tests/test_sharePermissions.py
+++ b/lib/oc-tests/test_sharePermissions.py
@@ -314,6 +314,10 @@ def finish_if_not_capable():
         #Dont test for <= 9.1 with new endpoint, since it is not supported
         logger.warn("Skipping test since webdav endpoint is not capable for this server version")
         return True
+    if compare_client_version('3.0', '>=') and use_new_dav_endpoint == False:
+        # Don't test for client version >= 3.0 with old endpoint, since it is not supported
+        logger.warn("Skipping test since old webdav endpoint is not support for this client version")
+        return True
     return False
 
 @add_worker

--- a/lib/oc-tests/test_uploadFiles.py
+++ b/lib/oc-tests/test_uploadFiles.py
@@ -85,6 +85,10 @@ def finish_if_not_capable():
         #Dont test for <= 9.1 with new endpoint, since it is not supported
         logger.warn("Skipping test since webdav endpoint is not capable for this server version")
         return True
+    if compare_client_version('3.0', '>=') and use_new_dav_endpoint == False:
+        # Don't test for client version >= 3.0 with old endpoint, since it is not supported
+        logger.warn("Skipping test since old webdav endpoint is not support for this client version")
+        return True
     return False
 
 @add_worker

--- a/lib/owncloud/test_chunking.py
+++ b/lib/owncloud/test_chunking.py
@@ -40,6 +40,10 @@ def finish_if_not_capable():
         #Dont test for <= 9.1 with new endpoint, since it is not supported
         logger.warn("Skipping test since webdav endpoint is not capable for this server version")
         return True
+    if compare_client_version('3.0', '>=') and use_new_dav_endpoint == False:
+        # Don't test for client version >= 3.0 with old endpoint, since it is not supported
+        logger.warn("Skipping test since old webdav endpoint is not support for this client version")
+        return True
     return False
 
 @add_worker

--- a/lib/owncloud/test_shareMountInit.py
+++ b/lib/owncloud/test_shareMountInit.py
@@ -116,6 +116,10 @@ def finish_if_not_capable():
         #Dont test for <= 9.1 with new endpoint, since it is not supported
         logger.warn("Skipping test since webdav endpoint is not capable for this server version")
         return True
+    if compare_client_version('3.0', '>=') and use_new_dav_endpoint == False:
+        # Don't test for client version >= 3.0 with old endpoint, since it is not supported
+        logger.warn("Skipping test since old webdav endpoint is not support for this client version")
+        return True
     return False
 
 @add_worker

--- a/lib/owncloud/test_sharePropagationGroups.py
+++ b/lib/owncloud/test_sharePropagationGroups.py
@@ -108,6 +108,10 @@ def finish_if_not_capable():
         #Dont test for <= 9.1 with new endpoint, since it is not supported
         logger.warn("Skipping test since webdav endpoint is not capable for this server version")
         return True
+    if compare_client_version('3.0', '>=') and use_new_dav_endpoint == False:
+        # Don't test for client version >= 3.0 with old endpoint, since it is not supported
+        logger.warn("Skipping test since old webdav endpoint is not support for this client version")
+        return True
     return False
 
 @add_worker

--- a/lib/owncloud/test_sharePropagationInsideGroups.py
+++ b/lib/owncloud/test_sharePropagationInsideGroups.py
@@ -107,6 +107,10 @@ def finish_if_not_capable():
         #Dont test for <= 9.1 with new endpoint, since it is not supported
         logger.warn("Skipping test since webdav endpoint is not capable for this server version")
         return True
+    if compare_client_version('3.0', '>=') and use_new_dav_endpoint == False:
+        # Don't test for client version >= 3.0 with old endpoint, since it is not supported
+        logger.warn("Skipping test since old webdav endpoint is not support for this client version")
+        return True
     return False
 
 @add_worker

--- a/lib/test_basicSync.py
+++ b/lib/test_basicSync.py
@@ -135,6 +135,10 @@ def finish_if_not_capable():
         #Dont test for <= 9.1 with new endpoint, since it is not supported
         logger.warn("Skipping test since webdav endpoint is not capable for this server version")
         return True
+    if compare_client_version('3.0', '>=') and use_new_dav_endpoint == False:
+        # Don't test for client version >= 3.0 with old endpoint, since it is not supported
+        logger.warn("Skipping test since old webdav endpoint is not support for this client version")
+        return True
     return False
     
 @add_worker

--- a/lib/test_concurrentDirRemove.py
+++ b/lib/test_concurrentDirRemove.py
@@ -60,6 +60,10 @@ def finish_if_not_capable():
         #Dont test for <= 9.1 with new endpoint, since it is not supported
         logger.warn("Skipping test since webdav endpoint is not capable for this server version")
         return True
+    if compare_client_version('3.0', '>=') and use_new_dav_endpoint == False:
+        # Don't test for client version >= 3.0 with old endpoint, since it is not supported
+        logger.warn("Skipping test since old webdav endpoint is not support for this client version")
+        return True
     return False
 
 @add_worker

--- a/lib/test_deltamove.py
+++ b/lib/test_deltamove.py
@@ -66,6 +66,10 @@ def finish_if_not_capable():
         #Dont test for <= 9.1 with new endpoint, since it is not supported
         logger.warn("Skipping test since webdav endpoint is not capable for this server version")
         return True
+    if compare_client_version('3.0', '>=') and use_new_dav_endpoint == False:
+        # Don't test for client version >= 3.0 with old endpoint, since it is not supported
+        logger.warn("Skipping test since old webdav endpoint is not support for this client version")
+        return True
     return False
 
 @add_worker

--- a/lib/test_nplusone.py
+++ b/lib/test_nplusone.py
@@ -45,6 +45,10 @@ def finish_if_not_capable():
         #Dont test for <= 9.1 with new endpoint, since it is not supported
         logger.warn("Skipping test since webdav endpoint is not capable for this server version")
         return True
+    if compare_client_version('3.0', '>=') and use_new_dav_endpoint == False:
+        # Don't test for client version >= 3.0 with old endpoint, since it is not supported
+        logger.warn("Skipping test since old webdav endpoint is not support for this client version")
+        return True
     return False
 
 @add_worker

--- a/python/smashbox/utilities/__init__.py
+++ b/python/smashbox/utilities/__init__.py
@@ -301,6 +301,21 @@ def get_conflict_files(d):
 
     return conflict_files
 
+def oc_server_url(protocol='http',user_num=None,hide_password=False):
+    """ Return the ownCloud URL """
+    if user_num is None:
+        username = "%s" % config.oc_account_name
+    else:
+        username = "%s%i" % (config.oc_account_name, user_num)
+
+    if hide_password:
+        password = "***"
+    else:
+        password = config.oc_account_password
+
+    return protocol + '://' + username + ':' + password + '@' + config.oc_server
+
+
 ######### WEBDAV AND SYNC UTILITIES #####################
 
 def oc_webdav_url(protocol='http',remote_folder="",user_num=None,webdav_endpoint=None,hide_password=False):
@@ -318,17 +333,7 @@ def oc_webdav_url(protocol='http',remote_folder="",user_num=None,webdav_endpoint
 
     remote_path = os.path.join(webdav_endpoint, config.oc_server_folder, remote_folder)
 
-    if user_num is None:
-        username = "%s" % config.oc_account_name
-    else:
-        username = "%s%i" % (config.oc_account_name, user_num)
-
-    if hide_password:
-        password = "***"
-    else:
-        password = config.oc_account_password
-
-    return protocol + '://' + username + ':' + password + '@' + config.oc_server + '/' + remote_path
+    return oc_server_url(protocol, user_num, hide_password).rstrip('/') + '/' + remote_path
 
 def oc_public_webdav_url(protocol='http',remote_folder="",token='',password=''):
     """ Get public Webdav URL
@@ -381,7 +386,7 @@ def run_ocsync(local_folder, remote_folder="", n=None, user_num=None, use_new_da
 
     for i in range(n):
         t0 = datetime.datetime.now()
-        cmd = config.oc_sync_cmd+' '+local_folder+' '+oc_webdav_url('owncloud',remote_folder,user_num) + " >> "+config.rundir+"/%s-ocsync.step%02d.cnt%03d.log 2>&1"%(reflection.getProcessName(),current_step,ocsync_cnt[current_step])
+        cmd = config.oc_sync_cmd+' '+local_folder+' '+oc_server_url('owncloud',user_num)+" >> "+config.rundir+"/%s-ocsync.step%02d.cnt%03d.log 2>&1"%(reflection.getProcessName(),current_step,ocsync_cnt[current_step])
         runcmd(cmd, ignore_exitcode=True)  # exitcode of ocsync is not reliable
         logger.info('sync cmd is: %s',cmd)
         logger.info('sync finished: %s',datetime.datetime.now()-t0)

--- a/python/smashbox/utilities/__init__.py
+++ b/python/smashbox/utilities/__init__.py
@@ -42,10 +42,11 @@ def compare_client_version(compare_to, operator):
     cmd += ' --version'
     rtn_code, std_out, std_err = runcmd(cmd)
 
+    version_semantic_length = len(compare_to.split('.'))
     version = std_out[std_out.find(' version ') + 9:]
-    if version[-4:-1] == 'git':
-        version = version[:-4]
-
+    version = version.strip().split(' ')[0]
+    version = version.split('.')[:version_semantic_length]
+    version = '.'.join(version)
     return version_compare(version, operator, compare_to)
 
 


### PR DESCRIPTION
The `3.0 cmd` client no longer accepts legacy URLs (old WebDAV) in the form of `https://demo.owncloud.com/remote.php/webdav/` (see https://github.com/owncloud/docs-client-desktop/issues/279).

There are test sets for both `'use_new_dav_endpoint':False` and `'use_new_dav_endpoint':True` that work fine for client version `2.11`. Since client version 3.0 doesn't accept old webdav endpoints, I thought it would be better to not run those tests against version 3.0.
So, this PR has skipped test sets that has `'use_new_dav_endpoint':False` when running against version 3.0.